### PR TITLE
Delete procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: cp .env.example .env && php artisan key:generate && heroku-php-apache2


### PR DESCRIPTION
To fix the error heroku-php-apache2: command not found